### PR TITLE
Add Codable Conformance

### DIFF
--- a/Sources/BijectiveDictionary/BijectiveDictionary.swift
+++ b/Sources/BijectiveDictionary/BijectiveDictionary.swift
@@ -204,3 +204,40 @@ public struct BijectiveDictionary<Left: Hashable, Right: Hashable> {
         }
     }
 }
+
+
+extension BijectiveDictionary: Encodable where Left: Encodable, Right: Encodable {
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(_ltr)
+    }
+}
+
+
+extension BijectiveDictionary: Decodable where Left: Decodable, Right: Decodable {
+    
+    
+    /// Decodes a bijective dictionary from a standard dictionary
+    ///
+    /// Initialization is delegated to ``init(_:)``. Therefore you should expect identical performance.
+    /// - Complexity: O(*n*), where *n* is the number of key-value pairs in the
+    ///   given dictionary.
+    ///
+    /// - Parameter decoder: the decoder used to decode the standard dictionary
+    /// - Throws: `DecodingError.dataCorruptedError` if the given dictionary does not have unique values.
+    /// `DecodingError.typeMismatch` if the encountered stored value is not a single value container.
+    /// `DecodingError.valueNotFound` if the encountered encoded value is null.`
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawKeyedDictionary = try container.decode([Left: Right].self)
+        
+        guard let dict = Self(rawKeyedDictionary) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "The decoded dictionary must have unique keys and unique values."
+            )
+        }
+        self = dict
+    }
+}
+

--- a/Tests/BijectiveDictionaryTests/BijectiveDictionaryTests.swift
+++ b/Tests/BijectiveDictionaryTests/BijectiveDictionaryTests.swift
@@ -7,6 +7,7 @@
 //  =============================================================
 
 #if swift(>=6.0)
+import Foundation
 import Testing
 @testable import BijectiveDictionary
 
@@ -196,5 +197,42 @@ func collection(dict: BijectiveDictionary<String, Int>) {
 @Test func rightValues() {
     let dict: BijectiveDictionary = ["A": 1, "B": 2, "C": 3]
     #expect(Set(dict.rightValues) == [1, 2, 3])
+}
+
+@Test("Encodable behavior should be equivalent to `Dictionary`")
+func encodableConformance() throws {
+    let dict = ["A": 1, "B": 2, "C": 3]
+    let bijectiveDict = BijectiveDictionary(dict)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    
+    let dictData = try encoder.encode(dict)
+    guard let dictJSONString = String(data: dictData, encoding: .utf8) else {
+        Issue.record(); return
+    }
+    
+    let bijectiveDictData = try encoder.encode(bijectiveDict)
+    guard let bijectiveDictJSONString = String(data: bijectiveDictData, encoding: .utf8) else {
+        Issue.record(); return
+    }
+    #expect(dictData == bijectiveDictData)
+    #expect(dictJSONString == bijectiveDictJSONString)
+}
+
+@Test("Decodable behavior should be equivalent to `Dictionary`")
+func decodableConformance() throws {
+    let jsonData = """
+{
+    "A": 1,
+    "B": 2,
+    "C": 3
+}
+""".data(using: .utf8)!
+    
+    let decoder = JSONDecoder()
+    let decoded = try decoder.decode(BijectiveDictionary<String, Int>.self, from: jsonData)
+    
+    let control = BijectiveDictionary(["A": 1, "B": 2, "C": 3])
+    #expect(decoded == control)
 }
 #endif


### PR DESCRIPTION
This PR adds `Codable` conformance to `BijectiveDictionary`. 

## Design
This conformance is designed so that encoding/decoding behavior should be equivalent to standard library `Dictionary`. (This is the approach that [IdentifiedArray](https://swiftpackageindex.com/pointfreeco/swift-identified-collections/main/documentation/identifiedcollections/identifiedarray) uses which has identical Codable behavior to `Array`.)

To accomplish this: 
- for **encoding**: I encoded the `_ltr` dictionary as is
- for **decoding**: I decoded the dictionary as is, then initialized a `BijectiveDictionary` using the [initializer](https://swiftpackageindex.com/ladvoc/bijectivedictionary/v0.1.2/documentation/bijectivedictionary/bijectivedictionary/init(_:)) that takes a `Dictionary`
  - perhaps it would be better to use `BijectiveDictionary(_:uniquingKeysWith:)` but I don't see that initializer in the package yet.
  
## Testing
Both encoding and decoding currently pass on 1,000 repeated tests. 

## Room For Further Improvement
Currently only [String: Int] is tested. We should add tests for other common Dictionary types. 

## Larger Context
This PR was heavily influenced by this [FiveStar](https://www.fivestars.blog/articles/codable-swift-dictionaries/) post. 

P.S. I would like to contribute further to this repo as well as use it in production. 