### PR TITLE
`Collection` conformance for `LeftValues` and `RightValues`

### DIFF
--- a/Sources/BijectiveDictionary/BijectiveDictionary+LeftValues.swift
+++ b/Sources/BijectiveDictionary/BijectiveDictionary+LeftValues.swift
@@ -60,8 +60,26 @@ extension BijectiveDictionary.LeftValues: Sequence {
 }
 
 // MARK: - Collection
-
-// TODO: implement collection
+extension BijectiveDictionary.LeftValues: Collection {
+  public typealias Index = Dictionary<Left, Right>.Index
+  public typealias Element = Left
+  
+  public var startIndex: Dictionary<Left, Right>.Index {
+    return _ltr.keys.startIndex
+  }
+  
+  public var endIndex: Dictionary<Left, Right>.Index {
+    return _ltr.keys.endIndex
+  }
+  
+  public func index(after i: Dictionary<Left, Right>.Index) -> Dictionary<Left, Right>.Index {
+    return _ltr.keys.index(after: i)
+  }
+  
+  public subscript(index: Dictionary<Left, Right>.Index) -> Left {
+    get { return _ltr.keys[index] }
+  }
+}
 
 // MARK: - Other Conformances
 

--- a/Sources/BijectiveDictionary/BijectiveDictionary+LeftValues.swift
+++ b/Sources/BijectiveDictionary/BijectiveDictionary+LeftValues.swift
@@ -77,24 +77,21 @@ extension BijectiveDictionary.LeftValues: Sequence {
 
 // MARK: - Collection
 extension BijectiveDictionary.LeftValues: Collection {
-  public typealias Index = Dictionary<Left, Right>.Index
-  public typealias Element = Left
-  
-  public var startIndex: Dictionary<Left, Right>.Index {
-    return _ltr.keys.startIndex
-  }
-  
-  public var endIndex: Dictionary<Left, Right>.Index {
-    return _ltr.keys.endIndex
-  }
-  
-  public func index(after i: Dictionary<Left, Right>.Index) -> Dictionary<Left, Right>.Index {
-    return _ltr.keys.index(after: i)
-  }
-  
-  public subscript(index: Dictionary<Left, Right>.Index) -> Left {
-    get { return _ltr.keys[index] }
-  }
+    
+    public typealias Index = BijectiveDictionary<Left, Right>.Index
+    
+    @inlinable public var startIndex: Index { Index(_ltr.startIndex) }
+    @inlinable public var endIndex: Index { Index(_ltr.endIndex) }
+    
+    @inlinable
+    public func index(after i: Index) -> Index {
+        Index(_ltr.index(after: i._ltrIndex))
+    }
+    
+    @inlinable
+    public subscript(position: Index) -> Left {
+        _ltr[position._ltrIndex].key
+    }
 }
 
 // MARK: - Other Conformances

--- a/Sources/BijectiveDictionary/BijectiveDictionary+RightValues.swift
+++ b/Sources/BijectiveDictionary/BijectiveDictionary+RightValues.swift
@@ -77,26 +77,22 @@ extension BijectiveDictionary.RightValues: Sequence {
 
 // MARK: - Collection
 extension BijectiveDictionary.RightValues: Collection {
-  public typealias Index = Dictionary<Right, Left>.Index
-  public typealias Element = Right
-  
-  public var startIndex: Dictionary<Right, Left>.Index {
-    return _rtl.keys.startIndex
-  }
-  
-  public var endIndex: Dictionary<Right, Left>.Index {
-    return _rtl.keys.endIndex
-  }
-  
-  public func index(after i: Dictionary<Right, Left>.Index) -> Dictionary<Right, Left>.Index {
-    return _rtl.keys.index(after: i)
-  }
-  
-  public subscript(index: Dictionary<Right, Left>.Index) -> Right {
-    get { return _rtl.keys[index] }
-  }
+    
+    public typealias Index = BijectiveDictionary<Left, Right>.Index
+    
+    @inlinable public var startIndex: Index { Index(_ltr.startIndex) }
+    @inlinable public var endIndex: Index { Index(_ltr.endIndex) }
+    
+    @inlinable
+    public func index(after i: Index) -> Index {
+        Index(_ltr.index(after: i._ltrIndex))
+    }
+    
+    @inlinable
+    public subscript(position: Index) -> Right {
+        _ltr[position._ltrIndex].value
+    }
 }
-
 // MARK: - Other Conformances
 
 extension BijectiveDictionary.RightValues: CustomStringConvertible {

--- a/Sources/BijectiveDictionary/BijectiveDictionary+RightValues.swift
+++ b/Sources/BijectiveDictionary/BijectiveDictionary+RightValues.swift
@@ -60,8 +60,26 @@ extension BijectiveDictionary.RightValues: Sequence {
 }
 
 // MARK: - Collection
-
-// TODO: implement collection
+extension BijectiveDictionary.RightValues: Collection {
+  public typealias Index = Dictionary<Right, Left>.Index
+  public typealias Element = Right
+  
+  public var startIndex: Dictionary<Right, Left>.Index {
+    return _rtl.keys.startIndex
+  }
+  
+  public var endIndex: Dictionary<Right, Left>.Index {
+    return _rtl.keys.endIndex
+  }
+  
+  public func index(after i: Dictionary<Right, Left>.Index) -> Dictionary<Right, Left>.Index {
+    return _rtl.keys.index(after: i)
+  }
+  
+  public subscript(index: Dictionary<Right, Left>.Index) -> Right {
+    get { return _rtl.keys[index] }
+  }
+}
 
 // MARK: - Other Conformances
 

--- a/Tests/BijectiveDictionaryTests/BijectiveDictionaryTests.swift
+++ b/Tests/BijectiveDictionaryTests/BijectiveDictionaryTests.swift
@@ -192,11 +192,23 @@ func collection(dict: BijectiveDictionary<String, Int>) {
 @Test func leftValues() {
     let dict: BijectiveDictionary = ["A": 1, "B": 2, "C": 3]
     #expect(Set(dict.leftValues) == ["A", "B", "C"])
+  
+    let leftValues = dict.leftValues
+    let assertions = ["A", "B", "C"]
+    for assertion in assertions {
+        #expect(leftValues.contains(assertion))
+    }
 }
 
 @Test func rightValues() {
     let dict: BijectiveDictionary = ["A": 1, "B": 2, "C": 3]
     #expect(Set(dict.rightValues) == [1, 2, 3])
+  
+    let rightValues = dict.rightValues
+    let assertions = [1, 2, 3]
+    for assertion in assertions {
+        #expect(rightValues.contains(assertion))
+    }
 }
 
 @Test("Encodable behavior should be equivalent to `Dictionary`")


### PR DESCRIPTION
This PR adds `Collection` conformance to `LeftValues` and `RightValues`. 

## Design Considerations
The intention is to map the values: 
- leftValues -> `LeftValues._ltr.keys`
- rightValues -> `RightValues._rtl.keys`

Hopefully this should allow the user to just treat a `BijectiveDictionary` as if it were a vanilla `Dictionary`, except they would use `.leftValues` and `.rightValues` instead of `.keys` and `.values`. 

### Order Preservation
I noticed that the docs now mention that `LeftValues` does not guarantee the order and that it might guarantee it in a future release. I think it makes sense not to guarantee the order, since the vanilla `Dictionary.Keys` does not guarantee the order. 