### PR TITLE
Fix inconsistent indexing between `LeftValues` and `RightValues`

### DIFF
--- a/Sources/BijectiveDictionary/BijectiveDictionary+LeftValues.swift
+++ b/Sources/BijectiveDictionary/BijectiveDictionary+LeftValues.swift
@@ -23,8 +23,9 @@ extension BijectiveDictionary {
     
     /// A collection containing just the left values of the dictionary.
     ///
-    /// When iterated over, order of the left values is not guaranteed. This may change
-    /// in a future release.
+    /// When iterated over, left values appear in this collection in the same order as they occur in the
+    /// dictionary’s left-right pairs. Each left value is unique.
+    ///
     /// ```swift
     /// let countryCodes: BijectiveDictionary = ["TW": "Taiwan", "AR": "Argentina"]
     /// print(countryCodes)

--- a/Sources/BijectiveDictionary/BijectiveDictionary+RightValues.swift
+++ b/Sources/BijectiveDictionary/BijectiveDictionary+RightValues.swift
@@ -23,8 +23,9 @@ extension BijectiveDictionary {
     
     /// A collection containing just the right values of the dictionary.
     ///
-    /// When iterated over, order of the right values is not guaranteed. This may change
-    /// in a future release.
+    /// When iterated over, right values appear in this collection in the same order as they occur in the
+    /// dictionary’s left-right pairs. Each right value is unique.
+    ///
     /// ```swift
     /// let countryCodes: BijectiveDictionary = ["TW": "Taiwan", "AR": "Argentina"]
     /// print(countryCodes)

--- a/Sources/BijectiveDictionary/BijectiveDictionary+RightValues.swift
+++ b/Sources/BijectiveDictionary/BijectiveDictionary+RightValues.swift
@@ -13,11 +13,11 @@ extension BijectiveDictionary {
     public struct RightValues {
         
         @usableFromInline
-        internal let _rtl: Dictionary<Right, Left>
+        internal let _ltr: Dictionary<Left, Right>
         
         @inlinable
-        internal init(_ rtl: Dictionary<Right, Left>) {
-            self._rtl = rtl
+        internal init(_ ltr: Dictionary<Left, Right>) {
+            self._ltr = ltr
         }
     }
     
@@ -41,7 +41,7 @@ extension BijectiveDictionary {
     ///
     @inlinable
     public var rightValues: RightValues {
-        RightValues(_rtl)
+        RightValues(_ltr)
     }
 }
 
@@ -55,22 +55,22 @@ extension BijectiveDictionary.RightValues: Sequence {
     public struct Iterator: IteratorProtocol {
         
         @usableFromInline
-        internal var keysIterator: Dictionary<Right, Left>.Keys.Iterator
+        internal var valuesIterator: Dictionary<Left, Right>.Values.Iterator
         
         @inlinable
-        internal init(keysIterator: Dictionary<Right, Left>.Keys.Iterator) {
-            self.keysIterator = keysIterator
+        internal init(valuesIterator: Dictionary<Left, Right>.Values.Iterator) {
+            self.valuesIterator = valuesIterator
         }
         
         @inlinable
         public mutating func next() -> Right? {
-            keysIterator.next()
+            valuesIterator.next()
         }
     }
     
     @inlinable
     public func makeIterator() -> Iterator {
-        Iterator(keysIterator: _rtl.keys.makeIterator())
+        Iterator(valuesIterator: _ltr.values.makeIterator())
     }
 }
 
@@ -81,11 +81,11 @@ extension BijectiveDictionary.RightValues: Sequence {
 // MARK: - Other Conformances
 
 extension BijectiveDictionary.RightValues: CustomStringConvertible {
-    public var description: String { _rtl.keys.description }
+    public var description: String { _ltr.values.description }
 }
 
 extension BijectiveDictionary.RightValues: CustomDebugStringConvertible {
-    public var debugDescription: String { _rtl.keys.debugDescription }
+    public var debugDescription: String { _ltr.values.debugDescription }
 }
 
 extension BijectiveDictionary.RightValues: Sendable


### PR DESCRIPTION
I noticed something I overlooked when I first implemented `LeftValues` and `RightValues`. In a standard `Dictionary`, `Keys` and `Values` share the same indices. That is, as long as the dictionary is not mutated and the indices remain stable, index $i$ corresponds to the same element regardless if accessed from `keys` or `values`:

```swift
var dict = [
    "a": 1,
    "b": 2,
    "c": 3
]

print(dict.keys[dict.startIndex])  // prints "b"
print(dict.values[dict.startIndex])  // prints "2"

dict["d"] = 4  // mutation invalidates indices

print(dict.keys[dict.startIndex]) // prints "a"
print(dict.values[dict.startIndex]) // prints "1"
```

This is the expected behavior for index-based access in a `Dictionary`. However, `BijectiveDictionary`'s current implementation has a bug. The reason the docs mention that order is not guaranteed for `leftValues` and `rightValues` is because `LeftValues` uses `_ltr` and `RightValues` uses `_rtl`. However, since `_rtl` is a separate dictionary, it has different indices. This means index $i$ refers to a different element in `leftValues` and `rightValues`. This behavior is unexpected and is not consistent with `Dictionary`.

Taking another look at this, there is no reason `RightValues` can’t also use `_ltr`; this pull request modifies `RightValues` accordingly.