### PR TITLE
Update BijectiveDictionary+Invariant.swift

### DIFF
--- a/Sources/BijectiveDictionary/BijectiveDictionary+Invariant.swift
+++ b/Sources/BijectiveDictionary/BijectiveDictionary+Invariant.swift
@@ -12,6 +12,18 @@ extension BijectiveDictionary {
         internal func _invariantCheck() {
             assert(_ltr.count == _rtl.count, "Internal dictionaries should always have same count after update.")
             // TODO: check keys and values.
+            for (leftKey, leftValue) in _ltr {
+                assert(
+                    _rtl[leftValue] == leftKey,
+                    "Internal dictionaries should have same key value pairs after update."
+                )
+            }
+            for (rightKey, rightValue) in _rtl {
+                assert(
+                    _ltr[rightValue] == rightKey,
+                    "Internal dictionaries should have same key value pairs after update."
+                )
+            }
         }
     #else
         @inlinable @inline(__always)


### PR DESCRIPTION
This PR attempts to resolve Issue #12. 
By using the value of one dictionary, as a key in the other dictionary, we should be able to assert that every key and value correctly matches each other across both dictionaries. 