### PR TITLE
Fix error in docs, document precondition

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ to as “left values” and “right values” respectively, to avoid confusion,
 to access the other.
 
 The following example demonstrates creating a bijective dictionary from a dictionary literal
-that maps time zones to their corresponding UTC offsets:
+that maps IANA time zones to their corresponding UTC offsets (not considering daylight savings time):
 
 ```swift
 var timeZones: BijectiveDictionary = [
@@ -40,7 +40,7 @@ The same subscripts can also be used to set values when the dictionary is mutabl
 
 ```swift
 timeZones[left: "Asia/Seoul"] = 9
-timeZones[right: 9.5] = "Australia/Darwin"
+timeZones[right: -9] = "America/Anchorage"
 ```
 
 ## Installation

--- a/Sources/BijectiveDictionary/BijectiveDictionary+Initializers.swift
+++ b/Sources/BijectiveDictionary/BijectiveDictionary+Initializers.swift
@@ -35,6 +35,8 @@ extension BijectiveDictionary {
     /// of left-right tuples with unique values on each side. Passing a sequence with duplicate
     /// values on either side to this initializer results in a runtime error. If your sequence might have duplicate
     /// keys, use the `BijectiveDictionary(_:uniquingKeysWith:)` initializer instead.
+    ///
+    /// - Precondition: The sequence must not have duplicate left or right values.
     @inlinable public init<S>(uniqueLeftRightPairs pairs: S) where S: Sequence, S.Element == (Left, Right) {
         defer { _invariantCheck() }
         self._ltr = Dictionary(uniqueKeysWithValues: pairs)

--- a/Sources/BijectiveDictionary/BijectiveDictionary.swift
+++ b/Sources/BijectiveDictionary/BijectiveDictionary.swift
@@ -50,7 +50,7 @@ public struct BijectiveDictionary<Left: Hashable, Right: Hashable> {
     /// Internal dictionary mapping right values to left values.
     @usableFromInline internal var _rtl: [Right: Left]
 
-    /// The total number of key-value pairs that the dictionary can contain without
+    /// The total number of left-right pairs that the dictionary can contain without
     /// allocating new storage.
     @inlinable public var capacity: Int {
         assert(_ltr.capacity == _rtl.capacity)

--- a/Sources/BijectiveDictionary/BijectiveDictionary.swift
+++ b/Sources/BijectiveDictionary/BijectiveDictionary.swift
@@ -19,7 +19,7 @@
 /// to access the other.
 ///
 /// The following example demonstrates creating a bijective dictionary from a dictionary literal
-/// that maps time zones to their corresponding UTC offsets:
+/// that maps IANA time zones to their corresponding UTC offsets (not considering daylight savings time):
 /// ```swift
 /// var timeZones: BijectiveDictionary = [
 ///     "America/Los_Angeles": -8,
@@ -38,8 +38,8 @@
 ///
 /// The same subscripts can also be used to set values when the dictionary is mutable:
 /// ```swift
-///  timeZones[left: "Asia/Seoul"] = 9
-///  timeZones[right: 9.5] = "Australia/Darwin"
+/// timeZones[left: "Asia/Seoul"] = 9
+/// timeZones[right: -9] = "America/Anchorage"
 /// ```
 ///
 public struct BijectiveDictionary<Left: Hashable, Right: Hashable> {


### PR DESCRIPTION
- Document the precondition for the `uniqueLeftRightPairs` initializer. Closes #17 
- Fix the basic usage example; it currently shows a `Double` being used as a right value.