### PR TITLE
Add BijectiveDictionaryBenchmark

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "3347a22db7ba977dae6f580fb11d404b4b2df7b1626b4c8b51a682f64ccbd4f3",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-collections-benchmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections-benchmark",
+      "state" : {
+        "revision" : "e8b88af0d678eacd65da84e99ccc1f0f402e9a97",
+        "version" : "0.0.3"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system",
+      "state" : {
+        "revision" : "d2ba781702a1d8285419c15ee62fd734a9437ff5",
+        "version" : "1.3.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,9 @@ let package = Package(
             name: "BijectiveDictionary",
             targets: ["BijectiveDictionary"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-collections-benchmark", from: "0.0.3"),
+    ],
     targets: [
         .target(
             name: "BijectiveDictionary",
@@ -19,6 +22,13 @@ let package = Package(
             dependencies: ["BijectiveDictionary"],
             swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]
         ),
+        .executableTarget(
+            name: "BijectiveDictionaryBenchmark",
+            dependencies: [
+                "BijectiveDictionary",
+                .product(name: "CollectionsBenchmark", package: "swift-collections-benchmark"),
+            ]
+        )
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -9,6 +9,9 @@ let package = Package(
             name: "BijectiveDictionary",
             targets: ["BijectiveDictionary"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-collections-benchmark", from: "0.0.3"),
+    ],
     targets: [
         .target(
             name: "BijectiveDictionary"
@@ -17,6 +20,13 @@ let package = Package(
             name: "BijectiveDictionaryTests",
             dependencies: ["BijectiveDictionary"]
         ),
+        .executableTarget(
+            name: "BijectiveDictionaryBenchmark",
+            dependencies: [
+                "BijectiveDictionary",
+                .product(name: "CollectionsBenchmark", package: "swift-collections-benchmark"),
+            ]
+        ),
     ],
-    swiftLanguageVersions: [.v6]
+    swiftLanguageModes: [.v6]
 )

--- a/Sources/BijectiveDictionaryBenchmark/main.swift
+++ b/Sources/BijectiveDictionaryBenchmark/main.swift
@@ -1,0 +1,63 @@
+import BijectiveDictionary
+import CollectionsBenchmark
+
+var benchmark = Benchmark(title: "BijectiveDictionary Benchmark")
+
+
+extension Sequence where Element == (left: String, right: Int) {
+    func insertedByLeftIntoBijectiveDictionary() -> BijectiveDictionary<String, Int> {
+        var bDict = BijectiveDictionary<String, Int>(minimumCapacity: underestimatedCount)
+        for element in self {
+            bDict[left: element.left] = element.right
+        }
+        return bDict
+    }
+    
+    func insertedByRightIntoBijectiveDictionary() -> BijectiveDictionary<String, Int> {
+        var bDict = BijectiveDictionary<String, Int>(minimumCapacity: underestimatedCount)
+        for element in self {
+            bDict[right: element.right] = element.left
+        }
+        return bDict
+    }
+    
+    func insertedIntoDictionary() -> Dictionary<String, Int> {
+        var dict = Dictionary<String, Int>(minimumCapacity: underestimatedCount)
+        for element in self {
+            dict[element.left] = element.right
+        }
+        return dict
+    }
+}
+
+
+
+benchmark.registerInputGenerator(
+    for: [(left: String, right: Int)].self) { size in
+        return (0..<size).map { index in
+            return (left: "String\(index)", right: index)
+        }
+    }
+
+benchmark.addSimple(
+    title: "BijectiveDictionary<String, Int> insertion into left",
+    input: [(left: String, right: Int)].self
+) { input in
+    blackHole(input.insertedByLeftIntoBijectiveDictionary())
+}
+
+benchmark.addSimple(
+    title: "BijectiveDictionary<String, Int> insertion into right",
+    input: [(left: String, right: Int)].self
+) { input in
+    blackHole(input.insertedByRightIntoBijectiveDictionary())
+}
+
+benchmark.addSimple(
+    title: "Dictionary<String, Int> insertion",
+    input: [(left: String, right: Int)].self
+) { input in
+    blackHole(input.insertedIntoDictionary())
+}
+
+benchmark.main()


### PR DESCRIPTION
This PR adds benchmark testing using https://github.com/apple/swift-collections-benchmark/tree/main
Resolves issue #14 

## Context
Helpful resources: 
1. https://github.com/apple/swift-collections-benchmark/blob/main/Documentation/01%20Getting%20Started.md
2. https://github.com/pointfreeco/swift-identified-collections/blob/main/Sources/swift-identified-collections-benchmark/main.swift

## Usage
To run benchmarks you can use: 
```zsh
swift run -c release BijectiveDictionaryBenchmark run --cycles 3 results
```
To chart benchmarks you can use: 
```zsh
swift run -c release BijectiveDictionaryBenchmark render results chart.png   
```
For more info see: https://github.com/apple/swift-collections-benchmark/blob/main/Documentation/01%20Getting%20Started.md#running-benchmarks

## Request For Comment
1. I think it would be helpful to compare at least some metrics to `Dictionary`. This can help us internally, as well as inform users of performance tradeoffs. 
2. When ready, I think we should add a Performance section to the README, with a graph of the benchmarks. Similar to this: https://github.com/pointfreeco/swift-identified-collections/tree/main#performance

## Room For Further Improvement
I will add tests lookups, removals, etc. 

## Note
`swiftLanguageVersions` is deprecated in Package.swift after Swift 6. We should use `swiftLanguageModes` instead. 