### PR TITLE
Add BijectiveDictionary.build()

### DIFF
--- a/Sources/BijectiveDictionary/BijectiveDictionary+build.swift
+++ b/Sources/BijectiveDictionary/BijectiveDictionary+build.swift
@@ -1,0 +1,95 @@
+public enum BijectiveDictionaryBuildResults<Left: Hashable, Right: Hashable> {
+    
+    case success(BijectiveDictionary<Left, Right>)
+    case conflicts(BijectiveDictionary<Left, Right>, conflicts: [BijectiveDictionary<Left, Right>.Element])
+}
+extension BijectiveDictionaryBuildResults: Sendable where Left: Sendable, Right: Sendable {}
+
+extension BijectiveDictionaryBuildResults: Equatable where Left: Equatable, Right: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case let (.success(lhsDict), .success(rhsDict)):
+            return lhsDict == rhsDict
+        case (.success, .conflicts):
+            return false
+        case (.conflicts, .success):
+            return true
+        case let (.conflicts(lhsDict, lhsConflicts), .conflicts(rhsDict, rhsConflicts)):
+            return lhsDict == rhsDict &&
+            lhsConflicts.map { $0.0 } == rhsConflicts.map { $0.0 } &&
+            lhsConflicts.map { $0.1 } == rhsConflicts.map { $0.1 }
+        }
+    }
+}
+
+extension BijectiveDictionary {
+    /// Builds a ``BijectiveDictionary`` from a collection of pairs
+    /// - Parameter pairs: A `Collection` of left-right pairs
+    /// - Returns: A `success` (with the dictionary) if there were no conflicts, or a `conflicts` (with the
+    /// incomplete dictionary, and the remaining conflicts that you need to resolve). 
+    @inlinable public static func build<C>(
+        from pairs: C
+    ) -> BijectiveDictionaryBuildResults<Left, Right> where C: Collection, C.Element == (Left, Right) {
+        // check if there are duplicates
+        // if there are conflicts: return `BijectiveDictionaryBuildResults.conflicts
+        // if there are NO conflicts: return `BijectiveDictionaryBuildResults.success`
+        
+        let keys = pairs.map { $0.0 }
+        let values = pairs.map { $0.1 }
+        let hasConflicts: Bool = keys.hasDuplicates || values.hasDuplicates
+        var insertedLeftValues: Set<Left> = []
+        var insertedRightValues: Set<Right> = []
+        if hasConflicts {
+            var conflicts: [BijectiveDictionary<Left, Right>.Element] = []
+            var dict = BijectiveDictionary<Left, Right>(minimumCapacity: pairs.count)
+            for (leftValue, rightValue) in pairs {
+                let alreadyInsertedLeftValue = insertedLeftValues.contains(leftValue) // O(1)
+                let alreadyInsertedRightValue = insertedRightValues.contains(rightValue) // O(1)
+                guard !alreadyInsertedLeftValue && !alreadyInsertedRightValue else {
+// Left, Right, or both values have already been inserted
+                    switch (alreadyInsertedLeftValue, alreadyInsertedRightValue) {
+                    case (true, true):
+                        conflicts.append((leftValue, rightValue))
+                        continue
+                    case (true, false):
+                        conflicts.append((leftValue, rightValue))
+                        continue
+                    case (false, true):
+                        conflicts.append((leftValue, rightValue))
+                        continue
+                    case (false, false):
+                        preconditionFailure("This state should not be possible here.")
+                        continue
+                    }
+                }
+                
+// Neither left nor right value has been inserted yet.
+                dict[left: leftValue] = rightValue
+                dict[right: rightValue] = leftValue
+                insertedLeftValues.insert(leftValue)
+                insertedRightValues.insert(rightValue)
+            }
+            return BijectiveDictionaryBuildResults.conflicts(dict, conflicts: conflicts)
+        } else {
+            // pairs has no conflicts
+            var dict = BijectiveDictionary<Left, Right>(minimumCapacity: pairs.count)
+            for (leftValue, rightValue) in pairs {
+                dict._ltr.updateValue(rightValue, forKey: leftValue)
+                dict._rtl.updateValue(leftValue, forKey: rightValue)
+            }
+            
+            return BijectiveDictionaryBuildResults.success(dict)
+        }
+    }
+}
+
+extension Collection where Element: Hashable {
+    public var hasDuplicates: Bool {
+        let selfAsSet = Set(self)
+        if self.count == selfAsSet.count {
+            return false
+        } else {
+            return true
+        }
+    }
+}

--- a/Tests/BijectiveDictionaryTests/BijectiveDictionaryTests.swift
+++ b/Tests/BijectiveDictionaryTests/BijectiveDictionaryTests.swift
@@ -299,4 +299,27 @@ func conflict() {
     #expect(dict.conflict(with: ("A", 1)) == .pair)
     #expect(dict.conflict(with: ("A", 3)) == .both(otherLeft: "C", otherRight: 1))
 }
+
+@Test func buildWithNoConflicts() {
+    let pairs = [("A", 1), ("B", 2), ("C", 3), ("D", 4)]
+    let actual = BijectiveDictionary.build(from: pairs)
+    let expected = BijectiveDictionaryBuildResults.success(["A": 1, "B": 2, "C": 3, "D": 4])
+    #expect(actual == expected)
+}
+
+@Test(arguments: [
+    ([("A", 1), ("B", 2), ("C", 3), ("A", 4)], BijectiveDictionaryBuildResults.conflicts(
+        ["A": 1, "B": 2, "C": 3],
+        conflicts: [("A", 4)]
+    )),
+    ([("A", 1), ("A", 2), ("C", 3), ("D", 3)], BijectiveDictionaryBuildResults.conflicts(
+        ["A": 1, "C": 3],
+        conflicts: [("A", 2), ("D", 3)]
+    ))
+])
+func buildWithConflicts(pairs: [(String, Int)], expected: BijectiveDictionaryBuildResults<String, Int>) {
+    let pairs = pairs
+    let actual = BijectiveDictionary.build(from: pairs)
+    #expect(actual == expected)
+}
 #endif


### PR DESCRIPTION
This PR is another potential solution to the uniquing problem. 

In this approach, we do a best effort attempt to create a `BijectiveDictionary` from a Collection of left-right pairs. 

If there are no conflicts, we return a `.success` with the completed `BijectiveDictionary`. 

If there are conflicts, we insert as many non-conflicting values as possible. We collect conflicting values as an Array. Then we return a `.conflicts` with the partial `BijectiveDictionary` and the remaining conflicting `Element`s so that the user can handle the conflicts themselves. 