### PR TITLE
Remove assertion of capacity being equal

### DIFF
--- a/Sources/BijectiveDictionary/BijectiveDictionary.swift
+++ b/Sources/BijectiveDictionary/BijectiveDictionary.swift
@@ -53,8 +53,7 @@ public struct BijectiveDictionary<Left: Hashable, Right: Hashable> {
     /// The total number of left-right pairs that the dictionary can contain without
     /// allocating new storage.
     @inlinable public var capacity: Int {
-        assert(_ltr.capacity == _rtl.capacity)
-        return _ltr.capacity
+        return Swift.min(_ltr.capacity, _rtl.capacity)
     }
 
     /// Reserves enough space to store the specified number of left-right pairs.


### PR DESCRIPTION
A dictionary's exact capacity is an unstable implementation detail, and it's theoretically possible that the capacities of both dictionaries become unequal (e.g. when an instance of a Left value takes substantially more memory than an instance of a Right value).